### PR TITLE
fix: remove ftp timeout

### DIFF
--- a/charts/paperlessngx-backup/templates/configmap.yaml
+++ b/charts/paperlessngx-backup/templates/configmap.yaml
@@ -56,7 +56,6 @@ data:
     ncftpput \
       -u "${FTP_USERNAME}" \
       -p "${FTP_PASSWORD}" \
-      -t ${{ .Values.timeout }} \
       "${FTP_HOST}" \
       "${FTP_PATH}" \
       "/backup-plngx/${FILENAME_ZIP}"


### PR DESCRIPTION
Option not supported in this ncftp version.

fixes #5